### PR TITLE
fix search, fileinfo plugin error

### DIFF
--- a/plugins/file_system/fileinfo/plugin.py
+++ b/plugins/file_system/fileinfo/plugin.py
@@ -66,11 +66,11 @@ else:
 
 result.append(['Absolute Path', absPath])
 
-print ''
-print 'File informations'
-print '================='
-print ''
+print ('')
+print ('File informations')
+print ('=================')
+print ('')
 for x in result:
-    print x[0]+(' '*(15-len(x[0])))+x[1]
+    print (x[0]+(' '*(15-len(x[0])))+x[1])
 
-print ''
+print ('')

--- a/plugins/file_system/search/plugin.py
+++ b/plugins/file_system/search/plugin.py
@@ -53,9 +53,9 @@ data = {"sep"  : "   ",
 number = len(http.response)
 title = "Found %s result%s matching %s in %s" % (str(number), ['','s'][number>1], pattern, absPath)
 
-print ''
-print title
-print '='*len(title)
-print ''
-print api.columnize(data)
-print ''
+print('')
+print(title)
+print('='*len(title))
+print('')
+print(api.columnize(data))
+print('')


### PR DESCRIPTION
run phpsploit under python3.5, 
get this error..

phpsploit > corectl reload-plugins 
[#] Couldn't compile plugin: « /opt/phpsploit/plugins/file_system/search »
[#] Traceback (most recent call last):
[#]   File "/opt/phpsploit/src/core/plugins/Plugin.py", line 56, in __init__
[#]     code = compile(script, "", "exec")
[#]   File "<string>", line 59
[#]     print('\n')
[#]         ^
[#] SyntaxError: invalid syntax
[#] 
[#] Couldn't compile plugin: « /opt/phpsploit/plugins/file_system/fileinfo »
[#] Traceback (most recent call last):
[#]   File "/opt/phpsploit/src/core/plugins/Plugin.py", line 56, in __init__
[#]     code = compile(script, "", "exec")
[#]   File "<string>", line 69
[#]     print ''
[#]            ^
[#] SyntaxError: Missing parentheses in call to 'print'
[#] 
[#] Plugin loader: 2 error(s) found
