### PR TITLE
fix machinery import

### DIFF
--- a/src/core/plugins/Plugin.py
+++ b/src/core/plugins/Plugin.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import importlib
+import importlib.machinery
 import traceback
 
 from datatypes import Path


### PR DESCRIPTION
see https://stackoverflow.com/questions/32987304/problems-when-converting-from-imp-to-importlib-in-python-3-4

i'm using python-3.5.2 on OSX