### PR TITLE
plugin/mysql: add PHP 7 compatibility

### DIFF
--- a/plugins/sql/mysql/connect.php
+++ b/plugins/sql/mysql/connect.php
@@ -1,12 +1,15 @@
 <?php
 
+!import(mysqli_compat)
+
 // Establish connection
 $host = $PHPSPLOIT["HOST"];
 $user = $PHPSPLOIT["USER"];
 $pass = $PHPSPLOIT["PASS"];
-$conn = @mysql_connect($host, $user, $pass);
+
+$conn = @mysqli_connect($host, $user, $pass);
 if (!$conn)
-    return error("ERROR: %s: %s", @mysql_errno(), @mysql_error());
+    return error("ERROR: %s: %s", @mysqli_connect_errno(), @mysqli_connect_error());
 
 //@mysql_close($connect);
 // NOTE:

--- a/plugins/sql/mysql/payload.php
+++ b/plugins/sql/mysql/payload.php
@@ -1,48 +1,50 @@
 <?php
 
+!import(mysqli_compat)
+
 // Establish connection
 $host = $PHPSPLOIT["HOST"];
 $user = $PHPSPLOIT["USER"];
 $pass = $PHPSPLOIT["PASS"];
-$conn = @mysql_connect($host, $user, $pass);
+$conn = @mysqli_connect($host, $user, $pass);
 if (!$conn)
-    return error("ERROR: %s: %s", @mysql_errno(), @mysql_error());
+    return error("ERROR: %s: %s", @mysqli_connect_errno(), @mysqli_connect_error());
 
 
 // Select database (if any)
 if (isset($PHPSPLOIT["BASE"]))
 {
-    $select = @mysql_select_db($PHPSPLOIT['BASE'], $conn);
+    $select = @mysqli_select_db($conn, $PHPSPLOIT['BASE']);
     if (!$select)
-        return error("ERROR: %s: %s", @mysql_errno(), @mysql_error());
+        return error("ERROR: %s: %s", @mysqli_errno($conn), @mysqli_error($conn));
 }
 
 
 // Send query
-$query = mysql_query($PHPSPLOIT['QUERY'], $conn);
+$query = mysqli_query($conn, $PHPSPLOIT['QUERY']);
 if (!$query)
-    return error("ERROR: %s: %s", @mysql_errno(), @mysql_error());
+    return error("ERROR: %s: %s", @mysqli_errno($conn), @mysqli_error($conn));
 
 
 // Query type: GET (information gathering)
-$rows = @mysql_num_rows($query);
+$rows = @mysqli_num_rows($query);
 if (is_int($rows))
 {
     $result = array();
-    $obj = mysql_fetch_array($query, MYSQL_ASSOC);
+    $obj = mysqli_fetch_array($query, MYSQLI_ASSOC);
     $result[] = array_keys($obj);
     $result[] = array_values($obj);
-    while ($line = mysql_fetch_array($query, MYSQL_ASSOC))
+    while ($line = mysqli_fetch_array($query, MYSQLI_ASSOC))
         $result[] = array_values($line);
     return array('GET', $rows, $result);
 }
 
 
 // Query type: SET (write into the database)
-$rows = @mysql_affected_rows();
+$rows = @mysqli_affected_rows($conn);
 if (is_int($rows))
     return array('SET', $rows);
 
-return error("ERROR: %s: %s", @mysql_errno(), @mysql_error());
+return error("ERROR: %s: %s", @mysqli_errno($conn), @mysqli_error($conn));
 
 ?>

--- a/plugins/sql/mysql/setdb.php
+++ b/plugins/sql/mysql/setdb.php
@@ -1,21 +1,23 @@
 <?php
 
+!import(mysqli_compat)
+
 // Establish connection
 $host = $PHPSPLOIT["HOST"];
 $user = $PHPSPLOIT["USER"];
 $pass = $PHPSPLOIT["PASS"];
-$conn = @mysql_connect($host, $user, $pass);
+$conn = @mysqli_connect($host, $user, $pass);
 if (!$conn)
-    return error("ERROR: %s: %s", @mysql_errno(), @mysql_error());
+    return error("ERROR: %s: %s", @mysqli_connect_errno(), @mysqli_connect_error());
 
 
 // Select database
 $base = $PHPSPLOIT["BASE"];
-$select = @mysql_select_db($base, $conn);
+$select = @mysqli_select_db($conn, $base);
 if (!$select)
-    return error("ERROR: %s: %s", @mysql_errno(), @mysql_error());
+    return error("ERROR: %s: %s", @mysqli_errno($conn), @mysqli_error($conn));
 
-//@mysql_close($connect);
+//@mysqli_close($connect);
 // NOTE:
 // commented due to a bug in rare servers (bug found in iis6.0/php5.2.11)
 

--- a/src/api/php-functions/mysqli_compat.php
+++ b/src/api/php-functions/mysqli_compat.php
@@ -1,0 +1,57 @@
+<?
+
+// MySQL compat mode for php 4:
+// define mysqli_*() functions from mysql_*() ones if MYSQLI is not available
+// loosely, only defined functions that are actually in use by mysql plugin.
+
+if (!function_exists("mysqli_connect")) {
+
+    // definitions
+    //
+    define("MYSQLI_ASSOC", MYSQL_ASSOC);
+
+    // functions
+    //
+    function mysqli_connect($host, $user, $pass) {
+        return mysql_connect($host, $user, $pass);
+    }
+
+    function mysqli_connect_error() {
+        return mysql_error();
+    }
+
+    function mysqli_connect_errno() {
+        return mysql_errno();
+    }
+
+    function mysqli_error($conn) {
+        return mysql_error($conn);
+    }
+
+    function mysqli_errno($conn) {
+        return mysql_errno($conn);
+    }
+
+    function mysqli_select_db($conn, $base) {
+        return mysql_select_db($base, $conn);
+    }
+
+    function mysqli_query($conn, $query_str) {
+        return mysql_query($query_str, $conn);
+    }
+
+    function mysqli_num_rows($query) {
+        return mysql_num_rows($query);
+    }
+
+    function mysqli_fetch_array($result, $resulttype) {
+        return mysql_fetch_array($result, $resulttype);
+    }
+
+    function mysqli_affected_rows($conn) {
+        return mysql_affected_rows($conn)
+    }
+
+}
+
+?>


### PR DESCRIPTION
on PHP 7, mysql_*() functions do not exist anymore, so the mysqli_*()
procedural style is now used on mysqli plugin sources.
Also, the new mysqli_compat.php include recreates mysqli_*()
functions from mysql_*() ones for php 4 targets, of php5 targets
without MYSQLI installed.