### PR TITLE
set/BROWSER: fix issue #128

### DIFF
--- a/src/datatypes/WebBrowser.py
+++ b/src/datatypes/WebBrowser.py
@@ -17,8 +17,17 @@ class WebBrowser(str):
     def __new__(cls, name):
         # a boring Mas OS/X case ..
         blacklist = ['macosx']
+
         lst = [x for x in webbrowser._browsers.keys() if x not in blacklist]
-        fmt = ", ".join(lst)
+        lst.append("disabled")
+        lst_repr = repr(lst)[1:-1]
+
+        if len(lst) < 2 or name == "disabled":
+            if name not in lst + ["", "default"]:
+                raise ValueError("Can't bind to «%s». Valid choices: %s"
+                        % (name, lst_repr))
+            return str.__new__(cls, "disabled")
+
         try:
             if name.lower() in ["", "default"]:
                 name = webbrowser.get().name
@@ -28,8 +37,8 @@ class WebBrowser(str):
         except AttributeError:
             return str.__new__(cls, "default")
         except:
-            raise ValueError("Can't bind to «%s». Try one of %s"
-                    % (name, fmt))
+            raise ValueError("Can't bind to «%s». Valid choices: %s"
+                    % (name, lst_repr))
         return str.__new__(cls, name)
 
     def _raw_value(self):
@@ -39,12 +48,20 @@ class WebBrowser(str):
         return self._raw_value()
 
     def __str__(self):
-        if self:
-            return colorize('%Cyan', self._raw_value())
+        val = self._raw_value()
+        if val == 'disabled':
+            return colorize('%Red', val)
+        elif val:
+            return colorize('%Cyan', val)
         else:
             return colorize('%Cyan', "default")
 
     def open(self, url):
-        browser = webbrowser.get(self._raw_value())
-        # try to open url in new browser tab
-        return browser.open_new_tab(url)
+        val = self._raw_value()
+        if val == "disabled":
+            print("[-] BROWSER is disabled, open the following URL manually:")
+            print("[-]   %s" % url)
+        else:
+            browser = webbrowser.get(self._raw_value())
+            # try to open url in new browser tab
+            return browser.open_new_tab(url)

--- a/test/RUN.sh
+++ b/test/RUN.sh
@@ -69,6 +69,11 @@ function assert_not_contains () {
         done
     fi
 }
+# FAIL if ARGV1 file has some output other than debug '[#]' lines
+function assert_no_output () {
+    [ -f "$1" ] || FAIL "file does not exist" / $1
+    grep -qv '\[\#\]' $1 && FAIL "file has some output" / $1
+}
 # remove ANSI colors from ARGV1 file
 function decolorize () {
     sed -ri "s/\x01?\x1B\[(([0-9]+)(;[0-9]+)*)?m\x02?//g" "$1"

--- a/test/settings/BROWSER.sh
+++ b/test/settings/BROWSER.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+############################################################
+### VALID VALUES
+############################################################
+phpsploit_pipe set BROWSER %%DEFAULT%% > $TMPFILE || FAIL
+assert_no_output $TMPFILE
+
+phpsploit_pipe set BROWSER default > $TMPFILE || FAIL
+assert_no_output $TMPFILE
+
+# issue #128: BROWSER default fails if no browser available
+# Ref: https://github.com/nil0x42/phpsploit/issues/128
+phpsploit_pipe set BROWSER disabled > $TMPFILE || FAIL
+assert_no_output $TMPFILE
+
+############################################################
+### INVALID VALUES
+############################################################
+phpsploit_pipe set BROWSER invalid_val > $TMPFILE && FAIL
+assert_contains $TMPFILE << EOF
+^\[\!\] Value Error: Can't bind to 'invalid_val'. Valid choices:
+'disabled'
+EOF


### PR DESCRIPTION
BROWSER 'default' value failed when local system has
no web browser installed (or at least detected by python webbrowser module.

A new 'disabled' value for BROWSER addresses this issue.
Setting BROWSER to `default` binds it to `disabled` as a fallback
if no other browsers are available.